### PR TITLE
xrp-example: #undef HAVE_THREADS; due to EXAMPLE_V2_CMD_LONG infinite looping

### DIFF
--- a/xrp-example/dsp_test.c
+++ b/xrp-example/dsp_test.c
@@ -29,6 +29,8 @@
 #include "example_namespace.h"
 #include "xrp_debug.h"
 
+#undef HAVE_THREADS
+
 void xrp_run_command(const void *in_data, size_t in_data_size,
 		     void *out_data, size_t out_data_size,
 		     struct xrp_buffer_group *buffer_group,


### PR DESCRIPTION
Within example_v2_handler(), with defined(HAVE_THREADS) true, command EXAMPLE_V2_CMD_LONG stays pending due to infinite looping waiting for a variable to be set, 